### PR TITLE
Upgrading pinenacl dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   collection: ^1.17.1
   convert: ^3.1.1
   http: ^1.1.0
-  pinenacl: ^0.5.1
+  pinenacl: ^0.6.0
   pointycastle: ^3.7.3
 
 dev_dependencies:


### PR DESCRIPTION
Method not found: 'UnmodifiableUint8ListView'. error in the latest flutter version

https://github.com/ilap/pinenacl-dart/issues/22